### PR TITLE
properly replace all rewritten links 

### DIFF
--- a/lib/rack/html.rb
+++ b/lib/rack/html.rb
@@ -18,7 +18,7 @@ module Rack
         new_response = []
 
         response.each do |line|
-          links = line.scan(/href="([^"]+)"/).uniq
+          links = line.scan(/href="([^"]+)"/).flatten.uniq
           res = line
           links.each do |link|
             t = get_translation(link)


### PR DESCRIPTION
I'm not sure why this worked earler but the Array need to be flattened apparently
